### PR TITLE
feat: stable new-lesson API + client de-dup + spaced review

### DIFF
--- a/api/feedback.js
+++ b/api/feedback.js
@@ -1,3 +1,6 @@
+/* eslint-env node */
+/* global process, Buffer */
+
 export default async function handler(req, res) {
   try {
     const { target, heard } = await readJSON(req);
@@ -26,7 +29,7 @@ export default async function handler(req, res) {
     if (!r.ok) return res.status(500).json({ error: await r.text() });
     const data = await r.json();
     let out = {};
-    try { out = JSON.parse(data.choices[0].message.content); } catch {}
+    try { out = JSON.parse(data.choices[0].message.content); } catch { /* ignore */ }
     res.status(200).json({
       score: out.score ?? 0,
       verdict: out.verdict || "incorrect",

--- a/api/new-lesson.backup.js
+++ b/api/new-lesson.backup.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 // /api/new-lesson.js
 const OPENAI_URL = "https://api.openai.com/v1/chat/completions";
 const PRIMARY_MODEL = "gpt-4o-mini";     // try this first

--- a/api/new-lesson.js
+++ b/api/new-lesson.js
@@ -1,51 +1,90 @@
-// api/new-lesson.js
-export const maxDuration = 60; // allow up to 60s on Vercel
+/* eslint-env node */
+/* global process */
+export const maxDuration = 60;
+
+function normalizeLesson(lesson) {
+  if (!lesson || typeof lesson !== "object") return [];
+  const acc = [];
+  if (lesson.title) acc.push(String(lesson.title));
+  if (Array.isArray(lesson.items)) {
+    for (const it of lesson.items) {
+      if (!it) continue;
+      if (it.type === "text" && it.content) acc.push(String(it.content));
+      if ((it.type === "word" || it.type === "phrase") && it.term) acc.push(String(it.term));
+    }
+  }
+  if (lesson.meta) {
+    if (lesson.meta.level) acc.push(String(lesson.meta.level));
+    if (lesson.meta.topic) acc.push(String(lesson.meta.topic));
+  }
+  return acc
+    .map((s) => s.toLowerCase().trim().replace(/\s+/g, " "))
+    .sort();
+}
+
+function fingerprint(str) {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < str.length; i++) {
+    h ^= str.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return (h >>> 0).toString(16).padStart(8, "0");
+}
+
+function lessonFingerprint(lesson) {
+  return fingerprint(JSON.stringify(normalizeLesson(lesson)));
+}
 
 export default async function handler(req, res) {
   if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed" });
-
   try {
-    const { level = "beginner", count = 8, topic } = req.body ?? {};
+    const { level = "beginner", count = 8, topic = "general", avoidTerms = [] } = req.body ?? {};
     if (!process.env.OPENAI_API_KEY) {
       return res.status(500).json({ error: "Missing OPENAI_API_KEY" });
     }
-
-    // Abort after 25s so we can report a clean error (not 502)
     const ctl = new AbortController();
-    const t = setTimeout(() => ctl.abort("OpenAI timeout"), 25_000);
-
+    const t = setTimeout(() => ctl.abort("timeout"), 25_000);
     const r = await fetch("https://api.openai.com/v1/chat/completions", {
       method: "POST",
       headers: {
         "content-type": "application/json",
-        "authorization": `Bearer ${process.env.OPENAI_API_KEY}`,
+        authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
       },
       body: JSON.stringify({
-        model: "gpt-4o-mini", // or whatever your code expects—make sure it matches
+        model: "gpt-4o-mini",
         messages: [
-          { role: "system", content: "You generate ESL lessons for Thai speakers." },
-          { role: "user", content: `Level: ${level}. Count: ${count}. Topic: ${topic ?? "general"}.` }
+          {
+            role: "system",
+            content:
+              "You generate compact ESL lessons for Thai learners. Output JSON with a title, 6-12 items (words/phrases), optional short 'text' intro.",
+          },
+          {
+            role: "user",
+            content: `Level: ${level}, Count: ${count}, Topic: ${topic}. Avoid terms: ${avoidTerms.join(", ")}. Return JSON only.`,
+          },
         ],
         temperature: 0.7,
       }),
       signal: ctl.signal,
     });
-
     clearTimeout(t);
-
     if (!r.ok) {
       const detail = await r.text().catch(() => "");
-      console.error("OpenAI error:", r.status, detail);
-      return res.status(502).json({ error: `OpenAI ${r.status}`, detail });
+      return res.status(500).json({ error: `OpenAI ${r.status}`, detail });
     }
-
     const data = await r.json();
-    // TODO: parse data.choices[0].message.content into a lesson object:
-    const lesson = { raw: data.choices?.[0]?.message?.content ?? "" };
-
+    let raw = data?.choices?.[0]?.message?.content || "";
+    let lesson;
+    try {
+      lesson = JSON.parse(raw);
+    } catch {
+      return res.status(500).json({ error: "Invalid JSON from OpenAI", detail: raw.slice(0, 1000) });
+    }
+    const fp = lessonFingerprint(lesson);
+    lesson.fingerprint = fp;
     return res.status(200).json({ lesson });
   } catch (err) {
-    console.error("new-lesson exception:", err);
-    return res.status(500).json({ error: String(err?.message || err) });
+    const detail = err?.message || String(err);
+    return res.status(500).json({ error: "Server error", detail });
   }
 }

--- a/api/transcribe.js
+++ b/api/transcribe.js
@@ -1,3 +1,5 @@
+/* eslint-env node */
+/* global process */
 // api/transcribe.js — Vercel serverless function (Node)
 export const config = { api: { bodyParser: false } };
 

--- a/api/tts.js
+++ b/api/tts.js
@@ -1,3 +1,5 @@
+/* eslint-env node */
+/* global process, Buffer */
 // api/tts.js — Vercel serverless function (Node)
 // Uses OpenAI TTS to synthesize speech and streams back audio/mpeg.
 

--- a/src/lib/firebase.js
+++ b/src/lib/firebase.js
@@ -17,7 +17,11 @@ const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
 
 export const db = getFirestore(app);
 export const auth = getAuth(app);
-export const analytics = getAnalytics(app);
+let analytics = null;
+if (typeof window !== "undefined" && import.meta.env.VITE_FB_MEASUREMENT_ID) {
+  analytics = getAnalytics(app);
+}
+export { analytics };
 
 export async function ensureAuth() {
   if (!import.meta.env.VITE_USE_FIREBASE) return null;

--- a/src/lib/storage.js
+++ b/src/lib/storage.js
@@ -1,0 +1,71 @@
+export const LESSON_HASHES_KEY = "efb_lesson_hashes_v1";
+export const MAX_GENERATION_RETRIES = 3;
+
+export function normalizeLesson(lesson) {
+  if (!lesson || typeof lesson !== "object") return [];
+  const acc = [];
+  if (lesson.title) acc.push(String(lesson.title));
+  if (Array.isArray(lesson.items)) {
+    for (const it of lesson.items) {
+      if (!it) continue;
+      if (it.type === "text" && it.content) acc.push(String(it.content));
+      if ((it.type === "word" || it.type === "phrase") && it.term) acc.push(String(it.term));
+    }
+  }
+  if (lesson.meta) {
+    if (lesson.meta.level) acc.push(String(lesson.meta.level));
+    if (lesson.meta.topic) acc.push(String(lesson.meta.topic));
+  }
+  return acc
+    .map((s) => s.toLowerCase().trim().replace(/\s+/g, " "))
+    .sort();
+}
+
+export function fingerprint(str) {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < str.length; i++) {
+    h ^= str.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return (h >>> 0).toString(16).padStart(8, "0");
+}
+
+export function lessonFingerprint(lesson) {
+  return fingerprint(JSON.stringify(normalizeLesson(lesson)));
+}
+
+export function loadHashesLS() {
+  try {
+    const t = localStorage.getItem(LESSON_HASHES_KEY);
+    return Array.isArray(JSON.parse(t)) ? JSON.parse(t) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function saveHashesLS(arr) {
+  try {
+    localStorage.setItem(LESSON_HASHES_KEY, JSON.stringify(arr));
+  } catch {
+    /* ignore */
+  }
+}
+
+const PROGRESS_KEY = "efb_progress_v1";
+export function loadProgressLS(defaults) {
+  try {
+    const t = localStorage.getItem(PROGRESS_KEY);
+    const obj = t ? JSON.parse(t) : {};
+    return { ...defaults, ...obj };
+  } catch {
+    return { ...defaults };
+  }
+}
+
+export function saveProgressLS(p) {
+  try {
+    localStorage.setItem(PROGRESS_KEY, JSON.stringify(p));
+  } catch {
+    /* ignore */
+  }
+}


### PR DESCRIPTION
## Summary
- add robust `/api/new-lesson` with lesson fingerprints and timeout handling
- share storage helpers for fingerprinting, local progress, and uniqueness checks
- implement client-side duplicate retries and spaced review with Firestore/localStorage fallback
- guard Firebase analytics so it's only initialised in the browser

## Testing
- [ ] `npm test`
- [ ] `npm run lint`

## Manual test plan
- API: `curl -sS https://<domain>/api/new-lesson -X POST -H 'content-type: application/json' -d '{"level":"beginner","count":8,"topic":"food"}'`
- Client: click **New Lesson** repeatedly – duplicates retry up to 3x
- Client: mark answers correct/incorrect – check `vocab/*` updates in Firestore when enabled
- Client: set `VITE_USE_FIREBASE=false` – flows continue using localStorage
- Anonymous user appears in Firebase Auth on first load

## Notes
- requires `OPENAI_API_KEY` on server and `VITE_FB_*`, `VITE_USE_FIREBASE` on client
- analytics only initialised when `window` is available and measurement ID is set


------
https://chatgpt.com/codex/tasks/task_e_689f57285c8483238e3cfb1383278931