### PR TITLE
feat: persistent lesson history with XP/streaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,18 @@ A lightweight English‑practice web app tailored for Thai speakers.
 - Mobile‑first UI (Tailwind + DaisyUI via CDN)
 - Text‑to‑Speech voice picker (Web Speech API)
 - Microphone practice via **Whisper** (serverless `/api/transcribe`)
-- Tracks progress locally or in Firestore (anonymous by default; email/password upgrade keeps data)
+- Tracks progress locally or in Firestore under a logged-in user account
 - Thai translations for lesson items (best effort)
 - Daily rotating tip on home and lesson screens
-- Login and registration screens with optional guest access
+- Login and registration screens (no guest mode)
+
+### Lessons & Progress
+
+- Completed lessons are stored per user (Firestore or local storage).
+- The **Lessons** tab lists prior lessons with a Repeat button to practice again.
+- XP is awarded only on the first completion of a lesson; repeats give no XP.
+- Level increases with total XP using a superlinear curve (100, 150, 225, ...).
+- Daily streak counts consecutive days with a completed lesson (America/New_York timezone).
 
 ## Quick Start (Codespaces or local Node 20+)
 
@@ -37,7 +45,7 @@ Set the following environment variable in **Project → Settings → Environment
 
 ### Firebase (optional)
 
-Set `VITE_USE_FIREBASE=true` and the `VITE_FB_*` config values to enable Firestore persistence. Users start anonymously; the login screen calls `loginEmail(email, password)` to sign in, and the registration screen uses `upgradeAnonToEmail(email, password)` to link the anonymous user so progress and lessons stay under the same UID.
+Set `VITE_USE_FIREBASE=true` and the `VITE_FB_*` config values to enable Firestore persistence. Authentication uses email/password and sessions persist via `browserLocalPersistence`.
 
 ### Daily Tips
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "firebase": "^12.1.0",
+        "luxon": "^3.5.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1"
       },
@@ -2997,6 +2998,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.1.tgz",
+      "integrity": "sha512-RkRWjA926cTvz5rAb1BqyWkKbbjzCGchDUIKMCUvNi17j6f6j8uHGDV82Aqcqtzd+icoYpELmG3ksgGiFNNcNg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/minimatch": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "firebase": "^12.1.0",
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "luxon": "^3.5.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.32.0",

--- a/src/lib/firebase.js
+++ b/src/lib/firebase.js
@@ -1,11 +1,11 @@
 import { initializeApp, getApps } from "firebase/app";
 import {
   getAuth,
-  signInAnonymously,
-  EmailAuthProvider,
-  linkWithCredential,
+  setPersistence,
+  browserLocalPersistence,
   signInWithEmailAndPassword,
   createUserWithEmailAndPassword,
+  signOut,
 } from "firebase/auth";
 import { getFirestore } from "firebase/firestore";
 import { getAnalytics } from "firebase/analytics";
@@ -24,6 +24,9 @@ const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
 
 export const db = getFirestore(app);
 export const auth = getAuth(app);
+if (typeof window !== "undefined") {
+  setPersistence(auth, browserLocalPersistence);
+}
 let analytics = null;
 if (typeof window !== "undefined" && import.meta.env.VITE_FB_MEASUREMENT_ID) {
   analytics = getAnalytics(app);
@@ -32,17 +35,7 @@ export { analytics };
 
 export async function ensureAuth() {
   if (!import.meta.env.VITE_USE_FIREBASE) return null;
-  const u = auth.currentUser;
-  if (u) return u;
-  await signInAnonymously(auth);
   return auth.currentUser;
-}
-
-export async function upgradeAnonToEmail(email, password) {
-  const user = auth.currentUser;
-  if (!user) throw new Error("No current user");
-  const cred = EmailAuthProvider.credential(email, password);
-  return linkWithCredential(user, cred);
 }
 
 export async function loginEmail(email, password) {
@@ -51,4 +44,8 @@ export async function loginEmail(email, password) {
 
 export async function registerEmail(email, password) {
   return createUserWithEmailAndPassword(auth, email, password);
+}
+
+export async function logout() {
+  return signOut(auth);
 }

--- a/src/lib/progress.js
+++ b/src/lib/progress.js
@@ -1,0 +1,39 @@
+import { DateTime } from "luxon";
+
+const TZ = "America/New_York";
+
+export function todayStr() {
+  return DateTime.now().setZone(TZ).toISODate();
+}
+
+export function xpNeededForLevel(level) {
+  return Math.round(100 * Math.pow(1.5, Math.max(0, level - 1)));
+}
+
+export function computeLevel(totalXp) {
+  let level = 1;
+  let xp = totalXp;
+  while (xp >= xpNeededForLevel(level)) {
+    xp -= xpNeededForLevel(level);
+    level += 1;
+  }
+  return { level, xpIntoLevel: xp, xpToNext: xpNeededForLevel(level) - xp };
+}
+
+export function updateStreakOnCompletion(profile) {
+  const today = todayStr();
+  const last = profile.lastActiveDate;
+  if (!last) {
+    return { streakCount: 1, lastActiveDate: today };
+  }
+  const dToday = DateTime.fromISO(today, { zone: TZ });
+  const dLast = DateTime.fromISO(last, { zone: TZ });
+  const diff = dToday.diff(dLast, "days").days;
+  if (diff < 1) {
+    return { streakCount: profile.streakCount, lastActiveDate: today };
+  } else if (diff >= 1 && diff < 2) {
+    return { streakCount: (profile.streakCount || 0) + 1, lastActiveDate: today };
+  } else {
+    return { streakCount: 1, lastActiveDate: today };
+  }
+}

--- a/src/lib/storage.js
+++ b/src/lib/storage.js
@@ -1,6 +1,18 @@
-import { collection, doc, getDoc, getDocs, setDoc } from "firebase/firestore";
+import {
+  collection,
+  doc,
+  getDoc,
+  getDocs,
+  setDoc,
+  updateDoc,
+  query,
+  orderBy,
+  limit as limitFn,
+  startAfter,
+} from "firebase/firestore";
 import { db, ensureAuth } from "./firebase";
 import { THAI_SEED } from "./thai-dict";
+import { computeLevel, updateStreakOnCompletion } from "./progress";
 
 export const LESSON_HASHES_KEY = "efb_lesson_hashes_v1";
 export const MAX_GENERATION_RETRIES = 3;
@@ -163,5 +175,143 @@ export function translateToThaiBulk(terms = []) {
     else if (!(t in out)) out[t] = "";
   }
   return out;
+}
+
+const LESSONS_KEY = "efb_lessons_v1";
+const PROFILE_KEY = "efb_profile_v1";
+const HASHES_KEY = "efb_hashes_v1";
+
+export async function saveLesson(lesson, { db, uid }) {
+  const id = lesson.id || Date.now().toString();
+  const data = {
+    title: lesson.title,
+    items: lesson.items,
+    fingerprint: lesson.fingerprint,
+    createdAt: lesson.createdAt || Date.now(),
+    completedAt: lesson.completedAt || null,
+    isRepeat: lesson.isRepeat || false,
+    source: lesson.source || "api",
+  };
+  if (!import.meta.env.VITE_USE_FIREBASE) {
+    const raw = localStorage.getItem(LESSONS_KEY);
+    const obj = raw ? JSON.parse(raw) : {};
+    obj[id] = { id, ...data };
+    localStorage.setItem(LESSONS_KEY, JSON.stringify(obj));
+    return id;
+  }
+  await setDoc(doc(db, `users/${uid}/lessons/${id}`), data);
+  return id;
+}
+
+export async function markLessonCompleted(lessonId, { db, uid, isRepeat }) {
+  const completed = { completedAt: Date.now(), isRepeat: !!isRepeat, source: isRepeat ? "repeat" : "api" };
+  if (!import.meta.env.VITE_USE_FIREBASE) {
+    const raw = localStorage.getItem(LESSONS_KEY);
+    const obj = raw ? JSON.parse(raw) : {};
+    if (obj[lessonId]) {
+      obj[lessonId] = { ...obj[lessonId], ...completed };
+      localStorage.setItem(LESSONS_KEY, JSON.stringify(obj));
+    }
+    return;
+  }
+  await updateDoc(doc(db, `users/${uid}/lessons/${lessonId}`), completed);
+}
+
+export async function listLessons({ db, uid, limit = 50, cursor } = {}) {
+  if (!import.meta.env.VITE_USE_FIREBASE) {
+    const raw = localStorage.getItem(LESSONS_KEY);
+    const obj = raw ? JSON.parse(raw) : {};
+    const arr = Object.values(obj).sort((a, b) => b.createdAt - a.createdAt);
+    return { lessons: arr.slice(0, limit), cursor: null };
+  }
+  let q = query(
+    collection(db, `users/${uid}/lessons`),
+    orderBy("createdAt", "desc"),
+    limitFn(limit)
+  );
+  if (cursor) q = query(q, startAfter(cursor));
+  const snap = await getDocs(q);
+  const lessons = [];
+  snap.forEach((d) => lessons.push({ id: d.id, ...d.data() }));
+  const last = snap.docs[snap.docs.length - 1];
+  return { lessons, cursor: last };
+}
+
+export async function hasFingerprint(fp, { db, uid }) {
+  if (!import.meta.env.VITE_USE_FIREBASE) {
+    const raw = localStorage.getItem(HASHES_KEY);
+    const arr = raw ? JSON.parse(raw) : [];
+    return arr.includes(fp);
+  }
+  const snap = await getDoc(doc(db, `users/${uid}/hashes/${fp}`));
+  return snap.exists();
+}
+
+export async function addFingerprint(fp, { db, uid }) {
+  if (!import.meta.env.VITE_USE_FIREBASE) {
+    const raw = localStorage.getItem(HASHES_KEY);
+    const arr = raw ? JSON.parse(raw) : [];
+    if (!arr.includes(fp)) {
+      arr.push(fp);
+      localStorage.setItem(HASHES_KEY, JSON.stringify(arr));
+    }
+    return;
+  }
+  await setDoc(doc(db, `users/${uid}/hashes/${fp}`), { fingerprint: fp, createdAt: Date.now() });
+}
+
+export async function loadProfile({ db, uid, defaults = {} }) {
+  if (!import.meta.env.VITE_USE_FIREBASE) {
+    const raw = localStorage.getItem(PROFILE_KEY);
+    const obj = raw ? JSON.parse(raw) : {};
+    return { ...defaults, ...obj };
+  }
+  const ref = doc(db, `users/${uid}/profiles/${uid}`);
+  const snap = await getDoc(ref);
+  if (snap.exists()) return { ...defaults, ...snap.data() };
+  const init = { ...defaults, createdAt: Date.now(), updatedAt: Date.now() };
+  await setDoc(ref, init);
+  return init;
+}
+
+export async function saveProfile(partial, { db, uid }) {
+  const data = { ...partial, updatedAt: Date.now() };
+  if (!import.meta.env.VITE_USE_FIREBASE) {
+    const raw = localStorage.getItem(PROFILE_KEY);
+    const obj = raw ? JSON.parse(raw) : {};
+    const merged = { ...obj, ...data };
+    localStorage.setItem(PROFILE_KEY, JSON.stringify(merged));
+    return merged;
+  }
+  const ref = doc(db, `users/${uid}/profiles/${uid}`);
+  await setDoc(ref, data, { merge: true });
+  const snap = await getDoc(ref);
+  return snap.data();
+}
+
+export async function finishLessonAndAward(lesson, { db, uid }) {
+  await markLessonCompleted(lesson.id, { db, uid, isRepeat: !!lesson.isRepeat });
+  const fp = lesson.fingerprint;
+  const isNew = !lesson.isRepeat && !(await hasFingerprint(fp, { db, uid }));
+  let awarded = 0;
+  if (isNew) {
+    await addFingerprint(fp, { db, uid });
+    awarded = 100;
+    let profile = await loadProfile({ db, uid, defaults: { xp: 0, level: 1, streakCount: 0 } });
+    const totalXp = (profile.xp || 0) + awarded;
+    const lvlInfo = computeLevel(totalXp);
+    const streak = updateStreakOnCompletion(profile);
+    profile = {
+      ...profile,
+      xp: totalXp,
+      level: lvlInfo.level,
+      streakCount: streak.streakCount,
+      lastActiveDate: streak.lastActiveDate,
+      lessonsCompleted: (profile.lessonsCompleted || 0) + 1,
+      updatedAt: Date.now(),
+    };
+    await saveProfile(profile, { db, uid });
+  }
+  return { awardedXp: awarded };
 }
 

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,20 +1,11 @@
-import { ensureAuth } from "./lib/firebase"; // NEW
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
 import "./index.css";
 
-(async () => {
-  // Wait for Firebase auth to finish before rendering
-  try {
-    await ensureAuth();
-  } catch (e) {
-    console.error("Firebase auth failed:", e);
-  }
+ReactDOM.createRoot(document.getElementById("root")).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);
 
-  ReactDOM.createRoot(document.getElementById("root")).render(
-    <React.StrictMode>
-      <App />
-    </React.StrictMode>
-  );
-})();

--- a/src/pages/Lessons.jsx
+++ b/src/pages/Lessons.jsx
@@ -1,0 +1,37 @@
+import React, { useEffect, useState } from "react";
+import { listLessons } from "../lib/storage";
+import { ensureAuth, db } from "../lib/firebase";
+
+export default function Lessons({ onRepeat }) {
+  const [lessons, setLessons] = useState([]);
+
+  useEffect(() => {
+    (async () => {
+      const u = await ensureAuth();
+      if (!u) return;
+      const { lessons } = await listLessons({ db, uid: u.uid, limit: 50 });
+      setLessons(lessons);
+    })();
+  }, []);
+
+  return (
+    <div className="card bg-base-100 w-full shadow p-4">
+      <h2 className="text-2xl font-bold mb-4">Lessons</h2>
+      <ul className="space-y-2">
+        {lessons.map((lsn) => (
+          <li key={lsn.id} className="flex justify-between items-center border-b pb-1">
+            <div>
+              <div className="font-semibold">{lsn.title}</div>
+              <div className="text-xs text-gray-500">
+                {new Date(lsn.createdAt).toLocaleDateString()} · {lsn.items ? lsn.items.length : 0} items {lsn.completedAt ? "· completed" : ""}
+              </div>
+            </div>
+            <button className="btn btn-sm" onClick={() => onRepeat(lsn)}>
+              Repeat
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- persist lessons per user and allow repeats without XP
- add XP level curve and daily streak tracking
- new Lessons page listing prior lessons and repeat option
- require email login before accessing the app; remove guest mode and anonymous auth

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f9f3e0d088323a158f25288a2cc85