### PR TITLE
feat(lessons): one active lesson with numbering

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,14 @@ A lightweight English‑practice web app tailored for Thai speakers.
 - Thai translations for lesson items (best effort)
 - Daily rotating tip on home and lesson screens
 - Login and registration screens (no guest mode)
+- Every lesson contains exactly 10 items with Thai translations
 
 ### Lessons & Progress
 
-- Completed lessons are stored per user (Firestore or local storage).
-- The **Lessons** tab lists prior lessons with a Repeat button to practice again.
-- XP is awarded only on the first completion of a lesson; repeats give no XP.
+- Linear lesson flow: exactly one active 10‑item lesson at a time.
+- Lessons are numbered and stored per user (Firestore or local storage).
+- The **Lessons** tab lists history with an Open button (no lesson creation).
+- XP is awarded only on the first completion of a lesson fingerprint.
 - Level increases with total XP using a superlinear curve (100, 150, 225, ...).
 - Daily streak counts consecutive days with a completed lesson (America/New_York timezone).
 

--- a/src/pages/Lessons.jsx
+++ b/src/pages/Lessons.jsx
@@ -2,15 +2,15 @@ import React, { useEffect, useState } from "react";
 import { listLessons } from "../lib/storage";
 import { ensureAuth, db } from "../lib/firebase";
 
-export default function Lessons({ onRepeat }) {
+export default function Lessons({ onOpen }) {
   const [lessons, setLessons] = useState([]);
 
   useEffect(() => {
     (async () => {
       const u = await ensureAuth();
       if (!u) return;
-      const { lessons } = await listLessons({ db, uid: u.uid, limit: 50 });
-      setLessons(lessons);
+      const arr = await listLessons({ db, uid: u.uid, limit: 50, order: "desc" });
+      setLessons(arr);
     })();
   }, []);
 
@@ -21,13 +21,13 @@ export default function Lessons({ onRepeat }) {
         {lessons.map((lsn) => (
           <li key={lsn.id} className="flex justify-between items-center border-b pb-1">
             <div>
-              <div className="font-semibold">{lsn.title}</div>
+              <div className="font-semibold">#{lsn.index} · {lsn.title}</div>
               <div className="text-xs text-gray-500">
-                {new Date(lsn.createdAt).toLocaleDateString()} · {lsn.items ? lsn.items.length : 0} items {lsn.completedAt ? "· completed" : ""}
+                {new Date(lsn.createdAt).toLocaleDateString()} · {lsn.itemsCount || 0} items · {lsn.status === "completed" ? "completed" : "incomplete"}
               </div>
             </div>
-            <button className="btn btn-sm" onClick={() => onRepeat(lsn)}>
-              Repeat
+            <button className="btn btn-sm" onClick={() => onOpen(lsn)}>
+              Open
             </button>
           </li>
         ))}


### PR DESCRIPTION
## Summary
- enforce server to return exactly 10 Thai-translated lesson items and compute fingerprints
- add storage helpers for profiles, active lesson management, and lesson creation
- wire client for linear flow with numbered lessons and active lesson practice

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a34f35b4348323b96e18af8d7742f1