### PR TITLE
feat(auth): split login/register pages; add password reset

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "firebase": "^12.1.0",
         "luxon": "^3.5.0",
         "react": "^19.1.1",
-        "react-dom": "^19.1.1"
+        "react-dom": "^19.1.1",
+        "react-router-dom": "^7.8.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.32.0",
@@ -2278,6 +2279,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3268,6 +3278,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.8.1.tgz",
+      "integrity": "sha512-5cy/M8DHcG51/KUIka1nfZ2QeylS4PJRs6TT8I4PF5axVsI5JUxp0hC0NZ/AEEj8Vw7xsEoD7L/6FY+zoYaOGA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.8.1.tgz",
+      "integrity": "sha512-NkgBCF3sVgCiAWIlSt89GR2PLaksMpoo3HDCorpRfnCEfdtRPLiuTf+CNXvqZMI5SJLZCLpVCvcZrTdtGW64xQ==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -3360,6 +3408,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -12,9 +12,10 @@
   },
   "dependencies": {
     "firebase": "^12.1.0",
+    "luxon": "^3.5.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
-    "luxon": "^3.5.0"
+    "react-router-dom": "^7.8.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.32.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { collection, doc, getDocs, setDoc } from "firebase/firestore";
 import { onAuthStateChanged } from "firebase/auth";
-import { auth, db, ensureAuth, loginEmail, registerEmail, logout } from "./lib/firebase";
+import { auth, db, ensureAuth, logout } from "./lib/firebase";
 import {
   loadHashes,
   upsertVocab,
@@ -73,8 +74,9 @@ function rootMeanSquare(buf) {
 
 /** ---------- MAIN APP ---------- **/
 export default function App() {
+  const navigate = useNavigate();
   // routing
-  const [view, setView] = useState("login");
+  const [view, setView] = useState("home");
 
   // profile progress
   const [profile, setProfile] = useState(DEFAULT_PROFILE);
@@ -92,9 +94,6 @@ export default function App() {
   // dynamic lesson state (replaces hard-coded lists at runtime)
   const [prompts, setPrompts] = useState([]); // English words/phrases
   const [thaiMap, setThaiMap] = useState({}); // { en: th }
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
-  const [authError, setAuthError] = useState("");
   const [lessonLoading, setLessonLoading] = useState(false);
   const [genStatus, setGenStatus] = useState("");
 
@@ -162,34 +161,11 @@ export default function App() {
           setCurrentLesson(null);
         }
         setView("home");
-      } else {
-        setProfile(DEFAULT_PROFILE);
-        setVocab(loadVocab());
-        setKnownHashes(new Set());
-        setCurrentLesson(null);
-        setView("login");
       }
     });
     return () => unsub();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-
-  async function handleLogin() {
-    try {
-      await loginEmail(email, password);
-    } catch (e) {
-      setAuthError(e.message);
-    }
-  }
-
-  async function handleRegister() {
-    try {
-      await registerEmail(email, password);
-    } catch (e) {
-      setAuthError(e.message);
-    }
-  }
-
   async function handleLogout() {
     try {
       await logout();
@@ -198,6 +174,7 @@ export default function App() {
     }
     localStorage.clear();
     resetPractice();
+    navigate("/login");
   }
 
   /** ---------- TTS (OpenAI via /api/tts) with fallback ---------- **/
@@ -513,10 +490,9 @@ export default function App() {
   return (
     <div className="min-h-screen bg-base-200 p-0 sm:p-6">
       {/* Navbar */}
-      {view !== "login" && view !== "register" && (
-        <div className="navbar bg-base-100 rounded-none sm:rounded-box shadow mb-6">
-          <div className="flex-1 px-2 text-xl font-bold">🐝 English for Bee</div>
-          <div className="flex-none flex items-center gap-2">
+      <div className="navbar bg-base-100 rounded-none sm:rounded-box shadow mb-6">
+        <div className="flex-1 px-2 text-xl font-bold">🐝 English for Bee</div>
+        <div className="flex-none flex items-center gap-2">
             <label className="label cursor-pointer gap-2">
               <span className="label-text">Voice</span>
               <select
@@ -551,59 +527,8 @@ export default function App() {
             <button className="btn btn-ghost" onClick={handleLogout}>Logout</button>
           </div>
         </div>
-      )}
 
       {/* Views */}
-      {view === "login" && (
-        <div className="card bg-base-100 w-full max-w-sm mx-auto shadow p-6">
-          <h2 className="text-2xl font-bold mb-2">Sign in</h2>
-          <input
-            type="email"
-            placeholder="Email"
-            className="input input-bordered w-full mb-2"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-          />
-          <input
-            type="password"
-            placeholder="Password"
-            className="input input-bordered w-full mb-2"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-          />
-          {authError && <p className="text-error text-sm mb-2">{authError}</p>}
-          <div className="flex flex-col gap-2">
-            <button className="btn btn-primary" onClick={handleLogin}>Login</button>
-            <button className="btn" onClick={() => { setAuthError(""); setView("register"); }}>Register</button>
-          </div>
-        </div>
-      )}
-
-      {view === "register" && (
-        <div className="card bg-base-100 w-full max-w-sm mx-auto shadow p-6">
-          <h2 className="text-2xl font-bold mb-2">Register</h2>
-          <input
-            type="email"
-            placeholder="Email"
-            className="input input-bordered w-full mb-2"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-          />
-          <input
-            type="password"
-            placeholder="Password"
-            className="input input-bordered w-full mb-2"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-          />
-          {authError && <p className="text-error text-sm mb-2">{authError}</p>}
-          <div className="flex flex-col gap-2">
-            <button className="btn btn-primary" onClick={handleRegister}>Create account</button>
-            <button className="btn" onClick={() => { setAuthError(""); setView("login"); }}>Back to login</button>
-          </div>
-        </div>
-      )}
-
       {view === "home" && (
         <div className="w-full">
           {/* Hero */}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,11 +1,37 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import ReactDOM from "react-dom/client";
+import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
+import { onAuthStateChanged } from "firebase/auth";
 import App from "./App";
+import Login from "./pages/Login";
+import Register from "./pages/Register";
+import { auth } from "./lib/firebase";
 import "./index.css";
+
+export function RequireAuth({ children }) {
+  const [user, setUser] = useState(undefined);
+  useEffect(() => {
+    return onAuthStateChanged(auth, (u) => setUser(u));
+  }, []);
+  if (user === undefined) return null;
+  return user ? children : <Navigate to="/login" replace />;
+}
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <Routes>
+        <Route path="/login" element={<Login />} />
+        <Route path="/register" element={<Register />} />
+        <Route
+          path="/*"
+          element={
+            <RequireAuth>
+              <App />
+            </RequireAuth>
+          }
+        />
+      </Routes>
+    </BrowserRouter>
   </React.StrictMode>
 );
-

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,0 +1,80 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { sendPasswordResetEmail } from "firebase/auth";
+import { auth, loginEmail } from "../lib/firebase";
+
+export default function Login() {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [msg, setMsg] = useState("");
+  const [error, setError] = useState("");
+  const navigate = useNavigate();
+
+  async function handleLogin() {
+    setError("");
+    try {
+      await loginEmail(email, password);
+      navigate("/");
+    } catch (e) {
+      setError(e.message.replace("Firebase: ", ""));
+    }
+  }
+
+  async function handleResetPassword() {
+    setError("");
+    setMsg("");
+    try {
+      await sendPasswordResetEmail(auth, email.trim());
+      setMsg("Reset email sent");
+    } catch (e) {
+      setError(e.message.replace("Firebase: ", ""));
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-base-200 p-0 sm:p-6">
+      <div className="navbar bg-base-100 rounded-none sm:rounded-box shadow mb-6">
+        <div className="flex-1 px-2 text-xl font-bold">🐝 English for Bee</div>
+      </div>
+      <div className="card bg-base-100 w-full max-w-sm mx-auto shadow p-6">
+        <h2 className="text-2xl font-bold mb-2">Sign in</h2>
+        <input
+          type="email"
+          placeholder="Email"
+          className="input input-bordered w-full mb-2"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          className="input input-bordered w-full mb-2"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        {error && <p className="text-error text-sm mb-2">{error}</p>}
+        <div className="flex flex-col gap-2 mb-2">
+          <button className="btn btn-primary" onClick={handleLogin}>Login</button>
+          <button className="btn" onClick={() => navigate("/register")}>Go to Register</button>
+        </div>
+        <button className="link link-primary text-sm" onClick={handleResetPassword}>
+          Forgot password?
+        </button>
+      </div>
+      {(msg || error) && (
+        <div className="toast toast-top toast-center">
+          {msg && (
+            <div className="alert alert-success">
+              <span>{msg}</span>
+            </div>
+          )}
+          {error && (
+            <div className="alert alert-error">
+              <span>{error}</span>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/Register.jsx
+++ b/src/pages/Register.jsx
@@ -1,0 +1,78 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { registerEmail } from "../lib/firebase";
+
+export default function Register() {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirm, setConfirm] = useState("");
+  const [msg, setMsg] = useState("");
+  const [error, setError] = useState("");
+  const navigate = useNavigate();
+
+  async function handleRegister() {
+    setError("");
+    if (password !== confirm) {
+      setError("Passwords do not match");
+      return;
+    }
+    try {
+      await registerEmail(email, password);
+      setMsg("Account created");
+      navigate("/");
+    } catch (e) {
+      setError(e.message.replace("Firebase: ", ""));
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-base-200 p-0 sm:p-6">
+      <div className="navbar bg-base-100 rounded-none sm:rounded-box shadow mb-6">
+        <div className="flex-1 px-2 text-xl font-bold">🐝 English for Bee</div>
+      </div>
+      <div className="card bg-base-100 w-full max-w-sm mx-auto shadow p-6">
+        <h2 className="text-2xl font-bold mb-2">Register</h2>
+        <input
+          type="email"
+          placeholder="Email"
+          className="input input-bordered w-full mb-2"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          className="input input-bordered w-full mb-2"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        <input
+          type="password"
+          placeholder="Confirm Password"
+          className="input input-bordered w-full mb-2"
+          value={confirm}
+          onChange={(e) => setConfirm(e.target.value)}
+        />
+        {error && <p className="text-error text-sm mb-2">{error}</p>}
+        <div className="flex flex-col gap-2">
+          <button className="btn btn-primary" onClick={handleRegister}>Create account</button>
+          <button className="btn" onClick={() => navigate("/login")}>Go to Login</button>
+        </div>
+      </div>
+      {(msg || error) && (
+        <div className="toast toast-top toast-center">
+          {msg && (
+            <div className="alert alert-success">
+              <span>{msg}</span>
+            </div>
+          )}
+          {error && (
+            <div className="alert alert-error">
+              <span>{error}</span>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- split login and register flows into dedicated pages with React Router
- add Firebase reset password link with toast messaging
- gate main app behind auth-aware routes and clean up old auth card

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a38d37480c8323be8e37d4b7448ce9