### PR TITLE
fix(practice): refine lesson progress and navigation

### DIFF
--- a/src/lib/storage.js
+++ b/src/lib/storage.js
@@ -139,6 +139,41 @@ export async function saveProgress(p) {
   }
 }
 
+const LESSON_PROGRESS_PREFIX = "efb_lp_";
+
+export function loadLessonProgress(lessonId) {
+  if (!lessonId) return { completedIndices: [], lastIdx: 0 };
+  try {
+    const raw = localStorage.getItem(LESSON_PROGRESS_PREFIX + lessonId);
+    if (!raw) return { completedIndices: [], lastIdx: 0 };
+    const obj = JSON.parse(raw);
+    return {
+      completedIndices: Array.isArray(obj.completedIndices) ? obj.completedIndices : [],
+      lastIdx: typeof obj.lastIdx === "number" ? obj.lastIdx : 0,
+    };
+  } catch {
+    return { completedIndices: [], lastIdx: 0 };
+  }
+}
+
+export function saveLessonProgress(lessonId, prog) {
+  if (!lessonId) return;
+  try {
+    localStorage.setItem(LESSON_PROGRESS_PREFIX + lessonId, JSON.stringify(prog));
+  } catch {
+    /* ignore */
+  }
+}
+
+export function clearLessonProgress(lessonId) {
+  if (!lessonId) return;
+  try {
+    localStorage.removeItem(LESSON_PROGRESS_PREFIX + lessonId);
+  } catch {
+    /* ignore */
+  }
+}
+
 export function upsertVocab(term, correct, existing = {}) {
   const entry = {
     term,


### PR DESCRIPTION
## Summary
- resume practice at the first unfinished word using saved per-word progress
- allow Next/Skip navigation without blocking on earlier items and only enable Finish when all ten are matched
- avoid reordering lesson items and persist completion immediately for each word

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4eb706a7883238b3a28934dd9d5fc